### PR TITLE
fix: schema-modeline

### DIFF
--- a/lua/yaml-companion/context/init.lua
+++ b/lua/yaml-companion/context/init.lua
@@ -147,6 +147,37 @@ M.autodiscover = function(bufnr, client)
   return {}
 end
 
+--- Re-run schema autodiscovery for a buffer after a modeline was added
+--- programmatically (auto-add / cluster auto-apply). yamlls only learns about
+--- the buffer change after the LSP debounce, so reset the cached state and poll
+--- a few times until a non-default schema resolves. This lets the statusline
+--- update without requiring a manual save+reload (:w/:e).
+---@param bufnr number
+M.schedule_refresh = function(bufnr)
+  if bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+  if not M.ctxs[bufnr] then
+    return
+  end
+
+  local attempts = 0
+  local function try()
+    local ctx = M.ctxs[bufnr]
+    if not ctx or not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    attempts = attempts + 1
+    ctx.executed = false
+    M.autodiscover(bufnr, ctx.client)
+    if ctx.schema.uri == schema.default().uri and attempts < 8 then
+      vim.defer_fn(try, 150)
+    end
+  end
+
+  vim.defer_fn(try, 150)
+end
+
 ---@param bufnr number
 ---@param client vim.lsp.Client
 M.setup = function(bufnr, client)

--- a/lua/yaml-companion/modeline/crd_detector.lua
+++ b/lua/yaml-companion/modeline/crd_detector.lua
@@ -172,6 +172,10 @@ function M.add_modelines(bufnr, options)
 
   notify_added_kinds(added_kinds, options.dry_run)
 
+  if result.added > 0 and not options.dry_run then
+    require("yaml-companion.context").schedule_refresh(bufnr)
+  end
+
   return result
 end
 
@@ -398,6 +402,9 @@ function M.add_modelines_with_fallback(bufnr, options, callback)
     if idx > #non_core_crds then
       -- Done processing all CRDs
       notify_added_kinds(added_kinds, options.dry_run)
+      if result.added > 0 and not options.dry_run then
+        require("yaml-companion.context").schedule_refresh(bufnr)
+      end
       callback(result)
       return
     end

--- a/lua/yaml-companion/schema_action.lua
+++ b/lua/yaml-companion/schema_action.lua
@@ -30,6 +30,9 @@ function M.apply(bufnr, schema, action, opts)
 
   if action == "modeline" then
     local success, was_modified = modeline.set_modeline(bufnr, schema.uri, line_number, false)
+    if success and was_modified then
+      require("yaml-companion.context").schedule_refresh(bufnr)
+    end
     if should_notify then
       if not success then
         notify.error("Failed to add modeline")


### PR DESCRIPTION
Refresh schema after programmatic modeline changes

When a schema modeline is added programmatically (auto-add, cluster auto-apply, or via schema_action), yamlls only picks up the change after its LSP debounce, so the statusline wouldn't update until a
manual :w/:e.

This adds context.schedule_refresh(bufnr), which resets the cached buffer state and polls autodiscovery a few times (every 150ms, up to 8 attempts) until a non-default schema resolves. It's now wired into
crd_detector.add_modelines, add_modelines_with_fallback, and schema_action.apply, so the statusline updates automatically without a save+reload.